### PR TITLE
Handle JSON parsing errors in state API

### DIFF
--- a/api/state.js
+++ b/api/state.js
@@ -30,11 +30,21 @@ export default async function handler(req, res) {
   try {
     if (req.method === "GET") {
       const { result } = await redis("GET", KEY);
-      return res.status(200).json(result ? JSON.parse(result) : {});
+      if (!result) return res.status(200).json({});
+      try {
+        return res.status(200).json(JSON.parse(result));
+      } catch (e) {
+        return res.status(400).json({ error: "Invalid JSON" });
+      }
     }
 
     if (req.method === "PUT") {
-      const payload = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+      let payload;
+      try {
+        payload = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+      } catch (e) {
+        return res.status(400).json({ error: "Invalid JSON" });
+      }
       await redis("SET", KEY, JSON.stringify(payload));
       return res.status(200).json({ ok: true });
     }

--- a/api/state.test.js
+++ b/api/state.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from './state.js';
+
+function createRes() {
+  const res = {
+    statusCode: 0,
+    headers: {},
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.body = data;
+      return this;
+    },
+    setHeader(key, value) {
+      this.headers[key] = value;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+  };
+  return res;
+}
+
+test('PUT invalid JSON returns 400', async () => {
+  process.env.UPSTASH_REDIS_REST_URL = 'url';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+
+  const req = { method: 'PUT', body: '{invalid}' };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { error: 'Invalid JSON' });
+});

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "express": "^4.19.2",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
   },
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   }
 }


### PR DESCRIPTION
## Summary
- return HTTP 400 with an error when request or stored state contains invalid JSON
- add test covering malformed request bodies
- expose `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc3c3d1c88328b21d81070be76a05