### PR TITLE
feat: add cors whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This is a Node.js project with an HTTP server.
 
 Add your [configuration](https://codesandbox.io/docs/projects/learn/setting-up/tasks) to optimize it for [CodeSandbox](https://codesandbox.io).
 
+## Configuration
+
+### Allowed Origins
+
+Set the `ALLOWED_ORIGINS` environment variable to a comma-separated list of URLs that are permitted to access the server. Requests from origins not in this list will be rejected.
+
+Example:
+
+```bash
+ALLOWED_ORIGINS="https://example.com,http://localhost:3000" npm start
+```
+
 ## How does this work?
 
 We run `yarn start` to start an HTTP server that runs on http://localhost:8080. You can open new or existing devtools with the + button next to the devtool tabs.

--- a/server.js
+++ b/server.js
@@ -12,7 +12,24 @@ const app = express();
 
 // parse json first
 app.use(express.json({ limit: "2mb" }));
-app.use(cors({ origin: "*", methods: ["GET", "PUT", "OPTIONS"] }));
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
+  .split(",")
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    methods: ["GET", "PUT", "OPTIONS"],
+  })
+);
 
 // serve your frontend from /public (make sure the folder exists)
 app.use(express.static(path.join(__dirname, "public")));


### PR DESCRIPTION
## Summary
- read allowed origins from `ALLOWED_ORIGINS`
- validate incoming origins with custom CORS function
- document `ALLOWED_ORIGINS` environment variable

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cc3c286e083289cea125c2ed0777b