### PR TITLE
docs: document Upstash Redis env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ Example:
 ALLOWED_ORIGINS="https://example.com,http://localhost:3000" npm start
 ```
 
+### State Persistence
+
+The serverless API uses [Upstash Redis](https://upstash.com/) to persist parking state between requests. Configure the connection using the following environment variables:
+
+- `UPSTASH_REDIS_REST_URL` – REST endpoint of your Upstash Redis database.
+- `UPSTASH_REDIS_REST_TOKEN` – authorization token for the database.
+
+You can define these values in a `.env` file:
+
+```env
+UPSTASH_REDIS_REST_URL=https://<region>.upstash.io
+UPSTASH_REDIS_REST_TOKEN=your-token-here
+```
+
+These variables enable the API to store and retrieve state from Redis, ensuring data survives across serverless invocations.
+
 ## How does this work?
 
 We run `yarn start` to start an HTTP server that runs on http://localhost:8080. You can open new or existing devtools with the + button next to the devtool tabs.


### PR DESCRIPTION
## Summary
- document Upstash Redis environment variables used for serverless state persistence
- add example `.env` configuration for Upstash URL and token

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd2346fec83288b038576e23f0480