### PR TITLE
Add SSE event stream and editor locking

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,22 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 
+// in-memory editor lock and SSE clients
+let editorId = null;
+const clients = new Set();
+let lockTimer = null;
+const LOCK_TIMEOUT = 30_000; // 30s
+
+function releaseLock(id) {
+  if (editorId === id) {
+    editorId = null;
+  }
+  if (lockTimer) {
+    clearTimeout(lockTimer);
+    lockTimer = null;
+  }
+}
+
 // parse json first
 app.use(express.json({ limit: "2mb" }));
 
@@ -28,7 +44,7 @@ app.use(
         callback(new Error("Not allowed by CORS"));
       }
     },
-    methods: ["GET", "PUT", "OPTIONS"],
+    methods: ["GET", "PUT", "POST", "DELETE", "OPTIONS"],
   })
 );
 
@@ -80,18 +96,40 @@ async function writeState(obj) {
 
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
+function eventsHandler(req, res) {
+  res.set({
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+
+  clients.add(res);
+  res.write("data: " + JSON.stringify(readState()) + "\n\n");
+
+  req.on("close", () => {
+    clients.delete(res);
+  });
+}
+
 function getStateHandler(_req, res) {
   res.set("Cache-Control", "no-store");
   res.json(readState());
 }
 
 async function putStateHandler(req, res) {
+  const id = req.get("x-editor-id");
+  if (id !== editorId) {
+    return res.status(403).json({ ok: false, error: "Forbidden" });
+  }
   const err = validateState(req.body);
   if (err) {
     return res.status(400).json({ ok: false, error: err });
   }
   const { spots, models, version } = req.body;
   const state = await writeState({ spots, models, version });
+  for (const client of clients) {
+    client.write("data: " + JSON.stringify(state) + "\n\n");
+  }
   res.json({ ok: true, state });
 }
 
@@ -99,6 +137,31 @@ app.get("/state", getStateHandler);
 app.get("/api/state", getStateHandler);
 app.put("/state", putStateHandler);
 app.put("/api/state", putStateHandler);
+
+function postLockHandler(req, res) {
+  const { id } = req.body || {};
+  if (!id) return res.status(400).json({ locked: false, editorId });
+
+  if (!editorId) {
+    editorId = id;
+    if (lockTimer) clearTimeout(lockTimer);
+    lockTimer = setTimeout(() => releaseLock(id), LOCK_TIMEOUT);
+    return res.json({ locked: true, editorId });
+  }
+  return res.json({ locked: editorId === id, editorId });
+}
+
+function deleteLockHandler(req, res) {
+  releaseLock(req.params.id);
+  res.json({ ok: true, editorId });
+}
+
+app.get("/events", eventsHandler);
+app.get("/api/events", eventsHandler);
+app.post("/lock", postLockHandler);
+app.post("/api/lock", postLockHandler);
+app.delete("/lock/:id", deleteLockHandler);
+app.delete("/api/lock/:id", deleteLockHandler);
 
 // catch-all: serve index.html if someone hits a route directly
 app.get("*", (_req, res) => {


### PR DESCRIPTION
## Summary
- track current editor and connected SSE clients in memory
- stream state updates over `GET /events`
- add lock endpoints and enforce `x-editor-id` on state updates

## Testing
- `npm test` *(fails: expected 4 failing tests, 2 passing)*

------
https://chatgpt.com/codex/tasks/task_e_689e21370a0483288ca917a6b7857090