### PR TITLE
Handle server-sent updates

### DIFF
--- a/public/remote.js
+++ b/public/remote.js
@@ -53,3 +53,8 @@ export async function remoteSave(payload) {
     return false;
   }
 }
+
+export function subscribe(onMessage) {
+  const es = new EventSource('/api/events');
+  es.onmessage = e => onMessage(JSON.parse(e.data));
+}

--- a/public/ui.js
+++ b/public/ui.js
@@ -1,5 +1,7 @@
-import { remoteLoad, remoteSave } from './remote.js';
+import { remoteLoad, remoteSave, subscribe } from './remote.js';
 import { canvas, layout, spotElMap, initLayout, renderSpotColor } from './layout.js';
+
+subscribe(updateFromServer);
 
 function safeSet(key, value) {
   try { localStorage.setItem(key, JSON.stringify(value)); }
@@ -160,6 +162,19 @@ async function saveState() {
   if (!ok) {
     console.warn("Remote save not available; using local only this time.");
   }
+}
+
+function updateFromServer(state) {
+  const spots = state?.spots || {};
+  layout.forEach((s) => {
+    const saved = spots[s.id];
+    if (saved) {
+      s.status = saved.status || "available";
+      s.vehicle = saved.vehicle || null;
+    }
+  });
+  layout.forEach(renderSpotColor);
+  refreshRightPanel();
 }
 
 /* =========================================================


### PR DESCRIPTION
## Summary
- Subscribe to server-sent events from the UI
- Update client layout from server state and refresh UI

## Testing
- `npm test` *(fails: Upstash GET failed: 500; status assertions 403)*

------
https://chatgpt.com/codex/tasks/task_e_689e22966fac8328b3ce060c6a5ca099