### PR TITLE
Simplify CORS configuration

### DIFF
--- a/server.js
+++ b/server.js
@@ -30,23 +30,7 @@ function releaseLock(id) {
 // parse json first
 app.use(express.json({ limit: "2mb" }));
 
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
-  .split(",")
-  .map((o) => o.trim())
-  .filter(Boolean);
-
-app.use(
-  cors({
-    origin: (origin, callback) => {
-      if (!origin || allowedOrigins.includes(origin)) {
-        callback(null, true);
-      } else {
-        callback(new Error("Not allowed by CORS"));
-      }
-    },
-    methods: ["GET", "PUT", "POST", "DELETE", "OPTIONS"],
-  })
-);
+app.use(cors());
 
 // serve your frontend from /public (make sure the folder exists)
 app.use(express.static(path.join(__dirname, "public")));


### PR DESCRIPTION
## Summary
- Simplify CORS handling by allowing all origins via cors()

## Testing
- `npm test` *(fails: Upstash GET failed: 500; PUT tests received 403)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_689e27ae14c08328814e29a04a4510b0