### PR TITLE
Persist parking state via Upstash Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ALLOWED_ORIGINS="https://example.com,http://localhost:3000" npm start
 
 ### State Persistence
 
-The serverless API uses [Upstash Redis](https://upstash.com/) to persist parking state between requests. Configure the connection using the following environment variables:
+The app can persist parking state using [Upstash Redis](https://upstash.com/) so that every browser sees the same data. Both the local server (`server.js`) and the serverless API consume the following environment variables:
 
 - `UPSTASH_REDIS_REST_URL` – REST endpoint of your Upstash Redis database.
 - `UPSTASH_REDIS_REST_TOKEN` – authorization token for the database.
@@ -30,7 +30,7 @@ UPSTASH_REDIS_REST_URL=https://<region>.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your-token-here
 ```
 
-These variables enable the API to store and retrieve state from Redis, ensuring data survives across serverless invocations.
+These variables enable the app to store and retrieve state from Redis, ensuring data survives across sessions and devices.
 
 ## How does this work?
 

--- a/api/state.test.js
+++ b/api/state.test.js
@@ -31,7 +31,7 @@ test('PUT invalid JSON returns 400', async () => {
   process.env.UPSTASH_REDIS_REST_URL = 'url';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
 
-  const req = { method: 'PUT', body: '{invalid}' };
+  const req = { method: 'PUT', body: '{invalid}', headers: { 'x-editor-id': null } };
   const res = createRes();
 
   await handler(req, res);
@@ -88,7 +88,7 @@ test('PUT persists state and returns ok', async () => {
   try {
     const payload = { spots: {}, models: {}, version: 1 };
     const resPut = createRes();
-    await handler({ method: 'PUT', body: payload }, resPut);
+    await handler({ method: 'PUT', body: payload, headers: { 'x-editor-id': null } }, resPut);
     assert.equal(resPut.statusCode, 200);
     assert.deepEqual(resPut.body, { ok: true });
 
@@ -109,7 +109,7 @@ test('PUT invalid state returns 400', async () => {
 
   try {
     const res = createRes();
-    await handler({ method: 'PUT', body: {} }, res);
+    await handler({ method: 'PUT', body: {}, headers: { 'x-editor-id': null } }, res);
     assert.equal(res.statusCode, 400);
     assert.deepEqual(res.body, { error: 'version must be a number' });
   } finally {
@@ -144,7 +144,7 @@ test('Upstash PUT failure returns 500', async () => {
   try {
     const res = createRes();
     const payload = { spots: {}, models: {}, version: 1 };
-    await handler({ method: 'PUT', body: payload }, res);
+    await handler({ method: 'PUT', body: payload, headers: { 'x-editor-id': null } }, res);
     assert.equal(res.statusCode, 500);
     assert.deepEqual(res.body, { error: 'Server error' });
   } finally {


### PR DESCRIPTION
## Summary
- Add optional Upstash Redis backing to `server.js` with fallback to local file storage and async state handlers.
- Document Redis configuration for shared persistence in the README.
- Adjust serverless API tests to use edit lock headers.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e7f06e29c83289820a08f8b9052db