### PR TITLE
Implement versioned syncing with offline fallback

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div id="offline-banner" style="display:none; background:#fcc; color:#900; padding:8px; text-align:center;">You're in local-only mode (not synced)</div>
     <div class="zoom-controls">
        <button id="zoom-in-btn">➕</button>
        <button id="zoom-out-btn">➖</button>


### PR DESCRIPTION
## Summary
- Track cached version from /api/state and sync with debounced PUT using `If-Match-Version`
- Display offline banner and persist state locally when remote sync fails
- Remove legacy locking and editor id logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ea00b18f883288731de968ec1da72