### PR TITLE
Validate input and nest state data

### DIFF
--- a/api/state.js
+++ b/api/state.js
@@ -24,7 +24,7 @@ const KEY = 'parking:state';
 const DEFAULT_STATE = {
   version: 0,
   updatedAt: null,
-  data: { spots: [], vehicles: [], models: [], stats: {} },
+  data: { spots: {}, models: {}, stats: {}, vehicles: [] },
 };
 
 const ORIGIN_RE = /^https?:\/\/([^\/]+\.)?(vercel\.app|csb\.app|codesandbox\.io)$/;
@@ -61,11 +61,16 @@ export default async function handler(req, res) {
       if (Number(matchVersion) !== currentVersion) {
         return res.status(409).json({ currentVersion });
       }
-      let data;
+      let parsedBody;
       try {
-        data = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+        parsedBody =
+          typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
       } catch {
         return res.status(400).json({ error: 'Invalid JSON' });
+      }
+      const { data } = parsedBody || {};
+      if (data === undefined) {
+        return res.status(400).json({ error: 'Missing data' });
       }
       state = {
         version: currentVersion + 1,

--- a/api/state.test.js
+++ b/api/state.test.js
@@ -42,7 +42,7 @@ test('GET returns default state', async () => {
   assert.deepEqual(res.body, {
     version: 0,
     updatedAt: null,
-    data: { spots: [], vehicles: [], models: [], stats: {} },
+    data: { spots: {}, models: {}, stats: {}, vehicles: [] },
   });
 });
 
@@ -50,7 +50,10 @@ test('PUT version mismatch returns 409', async () => {
   __reset();
   setEnv();
   const res = createRes();
-  await handler({ method: 'PUT', headers: { 'If-Match-Version': '1' }, body: {} }, res);
+  await handler(
+    { method: 'PUT', headers: { 'If-Match-Version': '1' }, body: { data: {} } },
+    res
+  );
   assert.equal(res.statusCode, 409);
   assert.deepEqual(res.body, { currentVersion: 0 });
 });
@@ -60,7 +63,7 @@ test('PUT increments version and persists', async () => {
   setEnv();
   const putRes = createRes();
   await handler(
-    { method: 'PUT', headers: { 'If-Match-Version': '0' }, body: { foo: 'bar' } },
+    { method: 'PUT', headers: { 'If-Match-Version': '0' }, body: { data: { foo: 'bar' } } },
     putRes
   );
   assert.equal(putRes.statusCode, 200);


### PR DESCRIPTION
## Summary
- Ensure PUT requests supply a `data` payload and return 400 when missing
- Store state as `{ version, updatedAt, data }` and adjust default shape
- Update tests to use nested `data` object

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c6e6488083289fbe77848fa80310