### PR TITLE
Simplify remote state subscription

### DIFF
--- a/public/remote.js
+++ b/public/remote.js
@@ -102,19 +102,6 @@ export function remoteSave(data) {
 
 export function subscribe(onMessage) {
   if (!REMOTE_ENABLED) return;
-  try {
-    const es = new EventSource('/api/events');
-    es.onmessage = (e) => onMessage(JSON.parse(e.data));
-    es.onerror = () => {
-      es.close();
-      startPolling(onMessage);
-    };
-  } catch {
-    startPolling(onMessage);
-  }
-}
-
-function startPolling(onMessage) {
   let last;
   async function poll() {
     try {

--- a/public/ui.js
+++ b/public/ui.js
@@ -1,7 +1,6 @@
-import { remoteLoad, remoteSave, subscribe } from './remote.js';
+import { remoteLoad, remoteSave } from './remote.js';
 import { canvas, layout, spotElMap, initLayout, renderSpotColor } from './layout.js';
 
-subscribe(updateFromServer);
 
 function safeSet(key, value) {
   try { localStorage.setItem(key, JSON.stringify(value)); }
@@ -140,19 +139,6 @@ function saveState() {
   // Try remote; also mirror local so offline reload shows latest saved state
   remoteSave(payload);
   try { safeSet(STORAGE_KEY, spots); } catch (e) { console.warn("local mirror failed:", e); }
-}
-
-function updateFromServer(state) {
-  const spots = state?.spots || {};
-  layout.forEach((s) => {
-    const saved = spots[s.id];
-    if (saved) {
-      s.status = saved.status || "available";
-      s.vehicle = saved.vehicle || null;
-    }
-  });
-  layout.forEach(renderSpotColor);
-  refreshRightPanel();
 }
 
 /* =========================================================


### PR DESCRIPTION
## Summary
- replace EventSource based remote subscribe with interval polling
- drop subscribe usage from the browser UI

## Testing
- `npm test` (fails: expected 200, got 500)


------
https://chatgpt.com/codex/tasks/task_e_68a0d01b726c8328a3a0ed27a859b429